### PR TITLE
Fix Vercel SpeedInsights placement

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -118,10 +118,10 @@ export default function RootLayout({ children }) {
           }}
         />
       </head>
-      <GoogleAnalytics />
-      <Analytics />
-      <SpeedInsights />
       <body className={`${inter.className} bg-white dark:bg-black min-h-screen`}>
+        <GoogleAnalytics />
+        <Analytics />
+        <SpeedInsights />
         <div className="relative z-10">
           <CustomThemeProvider>{children}</CustomThemeProvider>
         </div>


### PR DESCRIPTION
## Summary
- fix SpeedInsights usage by rendering it inside the `<body>` element

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a67471188324840064738dbd6485