### PR TITLE
Fix skeleton component naming

### DIFF
--- a/src/app/blog/[article-type]/[slug]/loading.js
+++ b/src/app/blog/[article-type]/[slug]/loading.js
@@ -1,8 +1,8 @@
-import SkeletionArticle from "@/components/Skeletions/SkeletionArticle";
+import SkeletonArticle from "@/components/Skeletons/SkeletonArticle";
 import React from "react";
 
 function loading() {
-  return <SkeletionArticle />;
+  return <SkeletonArticle />;
 }
 
 export default loading;

--- a/src/components/Skeletons/SkeletonArticle.jsx
+++ b/src/components/Skeletons/SkeletonArticle.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Skeleton } from "@mui/material";
 
-function SkeletionArticle() {
+function SkeletonArticle() {
   return (
     <section className="pt-0 relative w-full bg-white dark:bg-black">
       {/* Breadcrumb Navigation Skeleton */}
@@ -101,4 +101,4 @@ function SkeletionArticle() {
   );
 }
 
-export default SkeletionArticle;
+export default SkeletonArticle;


### PR DESCRIPTION
## Summary
- rename **Skeletions** component folder to **Skeletons**
- rename `SkeletionArticle.jsx` to `SkeletonArticle.jsx`
- update references to use `SkeletonArticle` component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513bd07ecc8324a9eeeaab9135a7a1