### PR TITLE
Center article content and reposition table of contents

### DIFF
--- a/src/app/blog/[article-type]/[slug]/page.jsx
+++ b/src/app/blog/[article-type]/[slug]/page.jsx
@@ -169,7 +169,7 @@ export default async function Page({ params }) {
         {/* Article Content */}
         <div className="relative max-w-4xl mx-auto px-8 pb-20">
           {showAside && headings.length > 0 && (
-            <div className="hidden xl:block absolute left-[-17rem] top-0 w-64">
+            <div className="hidden xl:block absolute left-[-17rem] top-0 w-64 h-full">
               <AsideTitles headings={headings} />
             </div>
           )}

--- a/src/app/blog/[article-type]/[slug]/page.jsx
+++ b/src/app/blog/[article-type]/[slug]/page.jsx
@@ -167,26 +167,26 @@ export default async function Page({ params }) {
         </div>
 
         {/* Article Content */}
-        <div className="max-w-7xl mx-auto px-8 pb-20">
-          <div className="flex gap-12 relative">
-            {/* Left sidebar for table of contents */}
-            <div className="hidden xl:block w-64 flex-shrink-0">
-              {showAside && headings.length > 0 && <AsideTitles headings={headings} />}
+        <div className="relative max-w-4xl mx-auto px-8 pb-20">
+          {showAside && headings.length > 0 && (
+            <div className="hidden xl:block absolute left-[-17rem] top-0 w-64">
+              <AsideTitles headings={headings} />
             </div>
-            
-            {/* Main article content */}
-            <article className="flex-1 max-w-4xl">
-              {/* Main Content */}
-              <section 
-                id="article-content"
-                className="prose prose-lg dark:prose-invert max-w-none
+          )}
+
+          {/* Main article content */}
+          <article className="max-w-none">
+            {/* Main Content */}
+            <section
+              id="article-content"
+              className="prose prose-lg dark:prose-invert max-w-none
                 prose-headings:font-light prose-headings:tracking-tight
                 prose-h1:text-4xl prose-h1:mb-8 prose-h1:mt-12
                 prose-h2:text-3xl prose-h2:mb-6 prose-h2:mt-10
                 prose-h3:text-2xl prose-h3:mb-4 prose-h3:mt-8
                 prose-p:leading-relaxed prose-p:text-gray-700 dark:prose-p:text-gray-300
                 prose-p:mb-6 prose-p:font-light prose-p:text-lg
-                prose-a:text-black dark:prose-a:text-white prose-a:no-underline 
+                prose-a:text-black dark:prose-a:text-white prose-a:no-underline
                 prose-a:border-b prose-a:border-gray-300 dark:prose-a:border-gray-600
                 hover:prose-a:border-black dark:hover:prose-a:border-white
                 prose-blockquote:border-l-2 prose-blockquote:border-gray-300 dark:prose-blockquote:border-gray-600
@@ -194,48 +194,47 @@ export default async function Page({ params }) {
                 prose-img:rounded-lg prose-img:shadow-lg prose-img:my-8
                 prose-code:bg-gray-100 dark:prose-code:bg-gray-800 prose-code:px-2 prose-code:py-1 prose-code:rounded
                 prose-pre:bg-gray-100 dark:prose-pre:bg-gray-900 prose-pre:border prose-pre:border-gray-200 dark:prose-pre:border-gray-700">
-                
-                <CustomMDX source={fileContent} showAside={showAside} />
-              </section>
 
-              {/* Article Footer */}
-              <footer className="mt-16 pt-12 border-t border-gray-200 dark:border-gray-800">
-                {/* Social Share Section */}
-                <div className="text-center mb-8">
-                  <div className="inline-flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400 font-mono mb-4">
-                    <div className="h-px w-8 bg-current opacity-50" />
-                    <span className="tracking-wider uppercase">Share this article</span>
-                    <div className="h-px w-8 bg-current opacity-50" />
+              <CustomMDX source={fileContent} showAside={showAside} />
+            </section>
+
+            {/* Article Footer */}
+            <footer className="mt-16 pt-12 border-t border-gray-200 dark:border-gray-800">
+              {/* Social Share Section */}
+              <div className="text-center mb-8">
+                <div className="inline-flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400 font-mono mb-4">
+                  <div className="h-px w-8 bg-current opacity-50" />
+                  <span className="tracking-wider uppercase">Share this article</span>
+                  <div className="h-px w-8 bg-current opacity-50" />
+                </div>
+                <SocialShare url={shareUrl} title={title} description={introduction} />
+              </div>
+
+              {/* Footer Info */}
+              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-6 pt-8 border-t border-gray-100 dark:border-gray-800/50">
+                {/* Article Metadata */}
+                <div className="flex items-center justify-center sm:justify-start gap-4 text-sm text-gray-500 dark:text-gray-400">
+                  <div className="flex items-center gap-2">
+                    <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full"></div>
+                    <span className="font-mono uppercase tracking-wider">{type}</span>
                   </div>
-                  <SocialShare url={shareUrl} title={title} description={introduction} />
+                  <div className="w-px h-4 bg-gray-300 dark:bg-gray-600"></div>
+                  <span className="font-mono">{formattedDate}</span>
                 </div>
 
-                {/* Footer Info */}
-                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-6 pt-8 border-t border-gray-100 dark:border-gray-800/50">
-                  {/* Article Metadata */}
-                  <div className="flex items-center justify-center sm:justify-start gap-4 text-sm text-gray-500 dark:text-gray-400">
-                    <div className="flex items-center gap-2">
-                      <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full"></div>
-                      <span className="font-mono uppercase tracking-wider">{type}</span>
-                    </div>
-                    <div className="w-px h-4 bg-gray-300 dark:bg-gray-600"></div>
-                    <span className="font-mono">{formattedDate}</span>
-                  </div>
-
-                  {/* Navigation */}
-                  <Link 
-                    href="/blog" 
-                    className="group inline-flex items-center justify-center sm:justify-start gap-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white transition-colors"
-                  >
-                    <svg className="w-4 h-4 transform transition-transform group-hover:-translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-                    </svg>
-                    <span className="font-mono tracking-wider uppercase">Back to Journal</span>
-                  </Link>
-                </div>
-              </footer>
-            </article>
-          </div>
+                {/* Navigation */}
+                <Link
+                  href="/blog"
+                  className="group inline-flex items-center justify-center sm:justify-start gap-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white transition-colors"
+                >
+                  <svg className="w-4 h-4 transform transition-transform group-hover:-translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                  </svg>
+                  <span className="font-mono tracking-wider uppercase">Back to Journal</span>
+                </Link>
+              </div>
+            </footer>
+          </article>
         </div>
       </section>
     </>

--- a/src/components/AsideTitles.jsx
+++ b/src/components/AsideTitles.jsx
@@ -114,9 +114,9 @@ export default function AsideTitles({ headings }) {
 
   return (
     <aside
-      className={`fixed top-32 left-8 w-64 max-h-[calc(100vh-200px)] overflow-y-auto p-6 bg-white/80 dark:bg-black/80 backdrop-blur-sm border border-gray-200/50 dark:border-gray-700/50 rounded-lg transition-all duration-300 ${
+      className={`sticky top-32 w-full max-h-[calc(100vh-200px)] overflow-y-auto p-6 bg-white/80 dark:bg-black/80 backdrop-blur-sm border border-gray-200/50 dark:border-gray-700/50 rounded-lg transition-all duration-300 ${
         isTableOfContentVisible ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-4"
-      } hidden xl:block z-10 custom-scrollbar`}
+      } z-10 custom-scrollbar`}
       id="table-of-content"
     >
       <div className="mb-6 pb-4 border-b border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- Center the article body by restructuring layout and absolutely positioning the adjacent table of contents
- Convert table of contents component to sticky positioning within layout

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae950267188324b8b50175c7f37354