### PR TITLE
Show read progress only on article pages

### DIFF
--- a/src/app/blog/[article-type]/[slug]/page.jsx
+++ b/src/app/blog/[article-type]/[slug]/page.jsx
@@ -6,6 +6,7 @@ import { BLUR_DATA_URLS } from "@/data/constants";
 import CustomMDX from "@/components/mdx/mdx-remote";
 import TableOfContents from "@/components/TableOfContents";
 import SocialShare from "@/components/SocialShare";
+import ReadProgressBar from "@/components/ReadProgressBar";
 import { formatDateString, generatePageMetadata } from "@/utils/index.js";
 import { extractHeadingsFromMDX } from "@/utils/extractHeadings";
 import { formatReadingTime } from "@/utils/readingTime";
@@ -71,6 +72,7 @@ export default async function Page({ params }) {
   
   return (
     <>
+      <ReadProgressBar />
       <Script
         id="article-schema"
         type="application/ld+json"

--- a/src/app/blog/layout.jsx
+++ b/src/app/blog/layout.jsx
@@ -1,6 +1,5 @@
 import CosmicFooter from "@/components/CosmisFooter";
 import Navbar from "@/components/LandingPage/Navbar";
-import ReadProgressBar from "@/components/ReadProgressBar";
 import Script from "next/script";
 import React from "react";
 
@@ -33,7 +32,6 @@ function Layout({ children }) {
           __html: JSON.stringify(blogBreadcrumbJsonLd)
         }}
       />
-      <ReadProgressBar />
       <Navbar />
       <main className="w-full pb-32">
         <section className="w-full grid place-items-center">{children}</section>


### PR DESCRIPTION
## Summary
- remove the global read progress bar from the blog layout
- mount the read progress indicator inside article detail pages instead

## Testing
- not run (next lint prompts for interactive setup)

------
https://chatgpt.com/codex/tasks/task_e_68dfbc4137648324a78abda0e03497bf