### PR TITLE
KAN-17 | check a11y, added proper implementation for Nav, Footer, Articles etc

### DIFF
--- a/docs/a11y-checklist.md
+++ b/docs/a11y-checklist.md
@@ -1,0 +1,36 @@
+# Accessibility checklist (WCAG 2.1 Level AA target)
+
+Use this for new components and PRs that touch UI. Pair with an axe scan on affected routes and a quick keyboard pass (Tab / Shift+Tab, Enter / Space, Escape where relevant).
+
+## Structure and semantics
+
+- One logical `<main>` per page with a stable `id` when using the site skip link (`#main-content`).
+- Use landmark elements intentionally: `header`, `nav`, `main`, `footer`, `aside`; give each `nav` a distinct `aria-label` if there is more than one.
+- Heading levels reflect outline order (no skipped levels; decorative text is not a heading).
+
+## Keyboard and focus
+
+- All interactive controls are focusable and operable with the keyboard; no `tabindex` traps except intentional dialogs (then provide Escape and focus return).
+- Focus order follows visual order; custom widgets expose correct roles and labels.
+- Do not remove `:focus-visible` styling; the project defines shared focus rings in `globals.css`.
+
+## Forms
+
+- Every input has a visible or programmatically associated `<label>` (`htmlFor` / `id` or wrapping `label`).
+- Use appropriate `type`, `name`, and `autocomplete` where applicable.
+- Submit success and error messages use a live region (`role="status"` and/or `aria-live="polite"`) when they appear dynamically.
+
+## Images and icons
+
+- Meaningful images have descriptive `alt` text; decorative images use `alt=""` or `aria-hidden` on the graphic.
+- Inline SVGs that repeat adjacent text are marked `aria-hidden="true"`.
+
+## Color and motion
+
+- Information is not conveyed by color alone; text/labels or patterns back up color coding.
+- Respect `prefers-reduced-motion` for non-essential animation (existing patterns in the codebase apply).
+
+## References
+
+- [WCAG 2.1](https://www.w3.org/TR/WCAG21/)
+- [axe DevTools](https://www.deque.com/axe/devtools/) for automated checks on representative pages

--- a/src/app/blog/layout.jsx
+++ b/src/app/blog/layout.jsx
@@ -33,7 +33,7 @@ function Layout({ children }) {
         }}
       />
       <Navbar />
-      <main className="w-full pb-32">
+      <main id="main-content" tabIndex={-1} className="w-full pb-32">
         <section className="w-full grid place-items-center">{children}</section>
       </main>
       <CosmicFooter variant="editorial" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -275,6 +275,36 @@ body {
   body {
     @apply bg-background text-foreground;
   }
+
+  /* WCAG 2.4.7 — visible keyboard focus (2.1 AA) */
+  :where(a, button, input, textarea, select, summary, [role="button"]):focus-visible {
+    outline: 2px solid hsl(217 91% 55%);
+    outline-offset: 2px;
+  }
+
+  .dark :where(a, button, input, textarea, select, summary, [role="button"]):focus-visible,
+  [data-theme="dark"] :where(a, button, input, textarea, select, summary, [role="button"]):focus-visible {
+    outline-color: hsl(213 94% 72%);
+  }
+}
+
+/* Skip link: off-screen until focused (2.4.1 Bypass Blocks) */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 1rem;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  border: 2px solid hsl(217 91% 55%);
+  border-radius: var(--radius);
+  font-weight: 500;
+  text-decoration: none;
+}
+.skip-link:focus {
+  left: 1rem;
+  outline: none;
 }
 
 /* Social Share hover backgrounds */

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -125,6 +125,9 @@ export default function RootLayout({ children }) {
         />
       </head>
       <body className={`${inter.className} bg-white dark:bg-black min-h-screen`}>
+        <a href="#main-content" className="skip-link">
+          Skip to main content
+        </a>
         <GoogleAnalytics />
         <Analytics />
         <SpeedInsights />

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -44,7 +44,7 @@ export default function Home() {
   };
 
   return (
-    <main>
+    <main id="main-content" tabIndex={-1}>
       <Script
         id="home-schema"
         type="application/ld+json"

--- a/src/components/ArticleCard.jsx
+++ b/src/components/ArticleCard.jsx
@@ -57,22 +57,20 @@ export default function ArticleCard({ details }) {
               placeholder="blur"
               className="object-cover transition-all duration-500 hover:scale-105"
               blurDataURL={BLUR_DATA_URLS.COVER_IMG}
-              alt={details.title}
+              alt={`Cover image for article: ${details.title}`}
             />
             <div className="absolute top-4 left-4 flex items-center">
-              <h3
+              <span
                 className={`rounded-lg bg-gradient-to-r from-black/70 to-black/60 text-sm tracking-wide font-medium text-white px-3 py-1.5 ${
                   details.disabled ? "rounded-r-none" : ""
                 }`}
               >
                 {details.type}
-              </h3>
+              </span>
               {details.disabled && (
-                <h3
-                  className="rounded-r-lg bg-amber-500/90 text-sm tracking-wide font-medium text-white px-3 py-1.5"
-                >
+                <span className="rounded-r-lg bg-amber-500/90 text-sm tracking-wide font-medium text-white px-3 py-1.5">
                   Coming soon
-                </h3>
+                </span>
               )}
             </div>
           </div>
@@ -92,7 +90,7 @@ export default function ArticleCard({ details }) {
             <div className="mt-auto pt-3 border-t border-border">
               <span className="text-sm font-semibold inline-flex items-center text-primary transition-transform group">
                 Read more
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="ml-1.5 group-hover:translate-x-1 transition-transform">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="ml-1.5 group-hover:translate-x-1 transition-transform" aria-hidden>
                   <path d="M5 12h14M12 5l7 7-7 7" />
                 </svg>
               </span>

--- a/src/components/ArticleCardOptimized.jsx
+++ b/src/components/ArticleCardOptimized.jsx
@@ -34,7 +34,7 @@ export default function ArticleCard({ details, index }) {
           {details.cover_img && (
             <Image
               src={details.cover_img}
-              alt={details.title}
+              alt={`Cover image for article: ${details.title}`}
               width={500}
               height={333}
               className="w-full h-full object-cover"
@@ -74,7 +74,7 @@ export default function ArticleCard({ details, index }) {
         {details.cover_img && (
           <Image
             src={details.cover_img}
-            alt={details.title}
+            alt={`Cover image for article: ${details.title}`}
             width={500}
             height={333}
             className="w-full h-full object-cover group-hover:scale-[1.04] transition-transform duration-700"

--- a/src/components/CosmisFooter/index.jsx
+++ b/src/components/CosmisFooter/index.jsx
@@ -271,39 +271,42 @@ function CosmicFooter({ variant = "default" }) {
 
             {/* Navigation Links Column */}
             <motion.div variants={itemVariants}>
-              <motion.h3
-                variants={itemVariants}
-                className={`text-xl ${variant === "editorial" ? "font-light" : "font-bold"} mb-4 tracking-tight`}
-              >
-                Navigate
-              </motion.h3>
-              <motion.ul
-                variants={containerVariants}
-                className={`space-y-2 text-sm ${theme.textSecondary}`}
-              >
-                {navItems.map((item, i) => (
-                  <motion.li
-                    key={item.name}
-                    variants={itemVariants}
-                    custom={i}
-                    className="relative flex items-center group"
-                  >
-                    <span
-                      className={`absolute left-0 w-0 h-[2px] ${theme.accentColor} rounded-full opacity-0 
+              <nav aria-label="Footer">
+                <motion.h3
+                  variants={itemVariants}
+                  className={`text-xl ${variant === "editorial" ? "font-light" : "font-bold"} mb-4 tracking-tight`}
+                >
+                  Navigate
+                </motion.h3>
+                <motion.ul
+                  variants={containerVariants}
+                  className={`space-y-2 text-sm ${theme.textSecondary}`}
+                >
+                  {navItems.map((item, i) => (
+                    <motion.li
+                      key={item.name}
+                      variants={itemVariants}
+                      custom={i}
+                      className="relative flex items-center group"
+                    >
+                      <span
+                        className={`absolute left-0 w-0 h-[2px] ${theme.accentColor} rounded-full opacity-0 
                       group-hover:w-2 group-hover:opacity-100 transition-all duration-300 ease-out`}
-                    />
-                    <Link
-                      href={item.href}
-                      className={`${theme.linkHoverColor} inline-block py-1 pl-0 
+                        aria-hidden
+                      />
+                      <Link
+                        href={item.href}
+                        className={`${theme.linkHoverColor} inline-block py-1 pl-0 
                       group-hover:pl-3 transition-all duration-300 ease-in-out transform
                       text-left cursor-pointer ${variant === "editorial" ? "font-light" : ""}`}
-                      style={{ transformOrigin: "left center" }}
-                    >
-                      {item.name}
-                    </Link>
-                  </motion.li>
-                ))}
-              </motion.ul>
+                        style={{ transformOrigin: "left center" }}
+                      >
+                        {item.name}
+                      </Link>
+                    </motion.li>
+                  ))}
+                </motion.ul>
+              </nav>
             </motion.div>
 
             {/* Connect Column */}

--- a/src/components/FeaturedArticle.jsx
+++ b/src/components/FeaturedArticle.jsx
@@ -107,7 +107,7 @@ export default function FeaturedArticle({ article }) {
                 placeholder="blur"
                 className="object-cover group-hover:scale-[1.03] transition-transform duration-700"
                 blurDataURL={BLUR_DATA_URLS.COVER_IMG}
-                alt={article.title}
+                alt={`Cover image for article: ${article.title}`}
               />
               <div className="absolute inset-0 bg-black/0 group-hover:bg-black/5 dark:group-hover:bg-black/10 transition-colors duration-300" />
             </div>

--- a/src/components/LandingPage/Navbar.jsx
+++ b/src/components/LandingPage/Navbar.jsx
@@ -25,6 +25,7 @@ function Navbar() {
 
   return (
     <motion.nav
+      aria-label="Blog"
       initial={{ opacity: 0, translateY: -40 }}
       animate={{ opacity: 1, translateY: 0 }}
       transition={{ duration: 0.5 }}

--- a/src/components/Logo/index.jsx
+++ b/src/components/Logo/index.jsx
@@ -11,9 +11,9 @@ const meowScript = Meow_Script({
 function Logo() {
   return (
     <Link href="/">
-      <h1 className={`cursor-pointer text-2xl ${meowScript.className} hover:opacity-80 transition-opacity duration-200`}>
+      <span className={`block cursor-pointer text-2xl ${meowScript.className} hover:opacity-80 transition-opacity duration-200`}>
         Ayushman
-      </h1>
+      </span>
     </Link>
   );
 }

--- a/src/components/NavButton.jsx
+++ b/src/components/NavButton.jsx
@@ -9,7 +9,7 @@ const NavButton = forwardRef(({ children, onClick, className = "", onMouseEnter,
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      className={`text-gray-400 px-4 py-2 rounded-full hover:bg-gray-800 hover:text-white transition-colors ${className}`}
+      className={`text-gray-400 px-4 py-2 rounded-full hover:bg-gray-800 hover:text-white transition-colors focus-visible:outline-offset-4 ${className}`}
     >
       {children}
     </button>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -26,7 +26,10 @@ const Navigation = ({ logo }) => {
   };
 
   return (
-    <nav className="flex items-center justify-between relative z-30">
+    <nav
+      className="flex items-center justify-between relative z-30"
+      aria-label="Primary"
+    >
       <div>{logo}</div>
 
       {!isMobile && (
@@ -54,10 +57,12 @@ const Navigation = ({ logo }) => {
 
       {isMobile && (
         <button
+          type="button"
           className="z-40 p-1"
           onClick={() => setIsOpen((prev) => !prev)}
-          aria-label="Toggle menu"
+          aria-label={isOpen ? "Close menu" : "Open menu"}
           aria-expanded={isOpen}
+          aria-controls="mobile-menu"
         >
           <HamburgerIcon isOpen={isOpen} />
         </button>
@@ -65,9 +70,11 @@ const Navigation = ({ logo }) => {
 
       {isMobile && (
         <div
+          id="mobile-menu"
           className={`fixed inset-0 z-30 bg-black/95 flex items-center justify-center transition-all duration-300 ${
             isOpen ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
           }`}
+          aria-hidden={!isOpen}
         >
           <ul
             className={`flex flex-col items-center space-y-6 transform transition-all duration-300 ${

--- a/src/components/Newsletter/index.jsx
+++ b/src/components/Newsletter/index.jsx
@@ -3,6 +3,8 @@
 import React, { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 
+const NEWSLETTER_EMAIL_ID = "newsletter-email";
+
 function Newsletter({ variant = "default" }) {
   const [email, setEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -104,15 +106,19 @@ function Newsletter({ variant = "default" }) {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <motion.p 
-          className={`text-sm ${theme.textColor} mb-3 ${variant === "editorial" ? "font-light" : ""}`}
-        >
-          Stay updated with latest posts
-        </motion.p>
-        
-        <form onSubmit={handleSubmit} className="flex gap-2 mb-2">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-2">
+          <label
+            htmlFor={NEWSLETTER_EMAIL_ID}
+            className={`text-sm ${theme.textColor} ${variant === "editorial" ? "font-light" : ""}`}
+          >
+            Stay updated with latest posts
+          </label>
+          <div className="flex gap-2">
           <motion.input
+            id={NEWSLETTER_EMAIL_ID}
             type="email"
+            name="email"
+            autoComplete="email"
             placeholder="Enter your email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -137,11 +143,14 @@ function Newsletter({ variant = "default" }) {
           >
             {isLoading ? 'Subscribing...' : 'Subscribe'}
           </motion.button>
+          </div>
         </form>
 
         {/* Status Message */}
         {statusMessage && (
           <motion.p
+            role="status"
+            aria-live="polite"
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             className={`text-xs ${statusMessage.color} ${variant === "editorial" ? "font-light" : ""}`}

--- a/src/components/ThemeSwitch/index.jsx
+++ b/src/components/ThemeSwitch/index.jsx
@@ -23,8 +23,9 @@ function ThemeSwitch() {
           data-theme={resolvedTheme}
           id="theme-toggle"
           title="Toggles light & dark"
-          aria-label={resolvedTheme}
-          aria-live="polite"
+          aria-label={
+            resolvedTheme === "dark" ? "Switch to light mode" : "Switch to dark mode"
+          }
           onClick={handleThemeToggler}
         >
           <svg


### PR DESCRIPTION
Improve accessibility (WCAG 2.1 AA–oriented)
## Summary
Small, shared fixes for keyboard users, focus visibility, semantics, forms, and screen readers on home, blog, and footer flows—without broad refactors.

## Changes
1. Skip link to `#main-content` in root layout; main on home and blog layouts marked with `id="main-content"` and `tabIndex={-1}`.
2. Global `:focus-visible` styles for interactive elements (light/dark).
3. Navigation: primary `aria-label`, mobile menu `aria-controls / aria-hidden`, clearer menu button labels.
4. Blog navbar & theme toggle: clearer `aria-labels`; logo markup adjusted so blog keeps a single primary `h1` (masthead).
5. Footer: footer `nav` wrapped in `<nav aria-label="Footer">`.
6. Article cards: heading order fixed (category chips not `h3` before title); clearer cover alt text; decorative SVGs aria-hidden.
7. Newsletter: associated `label`, `name` / `autoComplete`, `role="status"` + `aria-live` for feedback.
`docs/a11y-checklist.md`: checklist for new components/PRs.

## Testing
`npm test` (Vitest) — all passing.
Recommended: axe on /, /blog, and a sample article; quick keyboard + VoiceOver/NVDA spot-check.
