### PR TITLE
KAN-18 | Optimized caching model, api routing

### DIFF
--- a/docs/adr/0001-caching-model.md
+++ b/docs/adr/0001-caching-model.md
@@ -1,0 +1,69 @@
+# ADR 0001: Caching, revalidation, and CDN behavior (Odyssey)
+
+- **Status:** Accepted
+- **Date:** 2026-04-27
+- **Context:** The app mixes static/ISR pages, client-only pages, and dynamic API routes. We need a single place that describes how content stays fresh, what TTLs apply, and where configuration is easy to misread.
+
+## Decision
+
+We document the **intended** model below. HTTP `Cache-Control` (and Vercel-specific CDN headers) are the **authoritative** levers for edge caching of `GET` **Route Handlers**. Next.js **segment config** (`revalidate`, `dynamic`, `fetchCache`) applies to **RSC / pages** and to how the framework schedules work; for Route Handlers, `revalidate` does **not** replace explicit response headers. Where segment options conflict, we treat **response headers and runtime behavior** as the source of truth and align or fix code in follow-up work.
+
+## Caching model (summary)
+
+| Layer | Role |
+|--------|------|
+| **Vercel Edge / browser** | Honors `Cache-Control`, `CDN-Cache-Control`, `Vercel-CDN-Cache-Control` on API responses. |
+| **Next.js static / ISR (pages)** | `export const revalidate = N` (seconds) for pages that are statically generated or ISR. |
+| **Client-only pages** | No RSC data cache; assets via Next static pipeline. |
+| **Dynamic server routes** | Execute per request (or when the platform allows deduplication); must set headers explicitly to cache. |
+
+**Blog content** (`@/lib/posts` / MDX) is file-backed. The **blog index** uses ISR (1h). Individual article routes rely on the default `dynamicParams` behavior for new slugs; prebuilt paths are static. Staleness of the **list** and **feed** is bounded by the TTLs in the table below unless you add on-demand revalidation.
+
+## Route and API inventory (intended behavior)
+
+| Route | `revalidate` | `dynamic` / `fetchCache` | TTL / cache notes |
+|-------|----------------|----------------------------|-------------------|
+| `/` (`src/app/page.jsx`) | — | Client component root (no segment exports) | Static shell; client-loaded chunks. No server data cache. |
+| `/blog` | `3600` | `force-static`, `fetchCache: 'force-cache'` | ISR **1h**: blog list can lag new posts by up to 1h unless you revalidate or redeploy. |
+| `/blog/[article-type]/[slug]` | *(none)* | Default (static params + `generateStaticParams`) | Prebuilt posts are static. New slugs: generated on first request if not in the build. |
+| `/blog/[article-type]` (`route.js`) | — | Default dynamic | Search API: `GET` only; no `Cache-Control` (dynamic, typically uncached at CDN). |
+| `/collections` | — | Client page | No server cache. |
+| `GET /api/articles` | — | Default (dynamic route handler) | **Intended:** `public, s-maxage=3600, stale-while-revalidate=7200` (aligned with blog list / RSS). |
+| `GET /api/rss` | `3600` | `force-dynamic` | **Runtime** is dynamic; **edge** caches ~**1h** via response headers; `stale-while-revalidate=7200`. ETag is content-derived (see implementation). `Last-Modified` still reflects “now” on each build of the handler—consider aligning to latest article in a follow-up. |
+| `GET /api/spotify` | `1800` | `force-dynamic` | **Runtime** dynamic; **edge** caches **30m** via `Cache-Control`. Segment `revalidate` is redundant with `force-dynamic` for handler scheduling—**CDN TTL is the real control.** |
+| `GET/POST /api/views/[slug]` | — | Default | **Should not** be publicly cached: dynamic counts; set explicit `private, no-store` in a follow-up if needed. |
+| `GET/POST /api/reactions/[slug]` | — | Default | Same as views. |
+| `POST /api/newsletter/subscribe` | — | Default | Mutation; no shared cache. |
+| `POST /api/webhook` | — | Default | Mutation; no shared cache. |
+| `sitemap.xml` (`src/app/sitemap.js`) | — | Default | Regenerated per request in dev; in production, treated as a dynamic special route (see Next.js docs for caching of `sitemap`). |
+| `robots.txt` | — | Default | As above. |
+
+**Global `next.config.js` headers:** Security headers only; **no** global `Cache-Control` for HTML.
+
+## Misalignments and review findings
+
+1. **Blog list vs `force-static` + `revalidate`**  
+   `revalidate = 3600` defines ISR; `force-static` emphasizes static output. The effective story for product owners is: **list refreshes at most every hour** (and on deploy, depending on platform behavior).
+
+2. **`force-dynamic` + `revalidate` on `/api/rss` and `/api/spotify`**  
+   The handler remains **dynamic**; `revalidate` on the segment does not substitute for **HTTP cache** headers. Rely on documented `s-maxage` / `stale-while-revalidate` for edge behavior.
+
+3. **Hot paths**  
+   `/api/spotify` and `/api/rss` are the main intentionally CDN-cached GET APIs. **Views/reactions** should stay uncached for correctness.
+
+4. **RSS `Last-Modified`**  
+   Still set to “now” on each successful response; consider a follow-up to set from the latest article date for better semantics.
+
+## Recommended tracking issues (file in your tracker)
+
+| Title | Summary |
+|--------|---------|
+| **On-demand revalidation for MDX / blog** | Add `revalidatePath` / `revalidateTag` (or build hook) when content is published so the blog list and feed do not wait up to 1h. |
+| **Remove or clarify redundant segment config on Spotify/RSS** | Drop redundant `revalidate` where `force-dynamic` + CDN headers fully define behavior, or document why both are kept. |
+| **Explicit `Cache-Control: private, no-store` on views and reactions** | Prevents any intermediary from caching per-article JSON. |
+| **RSS `Last-Modified` from content** | Derive from max article `date` instead of `new Date()`. |
+
+## References
+
+- [Next.js: Route segment config](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config)
+- [Next.js: Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers)

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,17 @@ const withMDX = require("@next/mdx")();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Strip console.* in production (keeps error/warn) for smaller JS and less main-thread work
+  compiler: {
+    removeConsole:
+      process.env.NODE_ENV === "production"
+        ? { exclude: ["error", "warn"] }
+        : false,
+  },
+  experimental: {
+    // Tree-shake icon and motion imports to the symbols each file uses
+    optimizePackageImports: ["lucide-react", "framer-motion"],
+  },
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "m.media-amazon.com" },

--- a/src/app/api/articles/route.js
+++ b/src/app/api/articles/route.js
@@ -4,7 +4,11 @@ import { NextResponse } from 'next/server';
 export async function GET() {
   try {
     const articles = getArticles();
-    return NextResponse.json(articles);
+    return NextResponse.json(articles, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
+      },
+    });
   } catch (error) {
     console.error('Error fetching articles:', error);
     return NextResponse.json(

--- a/src/app/api/rss/route.js
+++ b/src/app/api/rss/route.js
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { getArticles } from '@/lib/posts';
 import RSS from 'rss';
@@ -128,6 +129,7 @@ export async function GET(request) {
 
     // Generate RSS XML with dynamic URL based on request
     const rssXml = generateRSSFeed(articles, request.url);
+    const etag = `"${createHash('sha1').update(rssXml).digest('hex')}"`;
 
     // Return RSS feed with proper headers for SEO and caching
     return new NextResponse(rssXml, {
@@ -147,7 +149,7 @@ export async function GET(request) {
         // Additional SEO headers
         'X-Robots-Tag': 'index, follow',
         'Last-Modified': new Date().toUTCString(),
-        'ETag': `"rss-${Date.now()}"`,
+        ETag: etag,
       },
     });
 

--- a/src/components/MyStack/components/SkillTree.jsx
+++ b/src/components/MyStack/components/SkillTree.jsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from 'react';
-import * as d3 from 'd3';
+import { select, selectAll } from 'd3-selection';
+import { tree as treeLayoutFactory, hierarchy } from 'd3-hierarchy';
+import { ascending } from 'd3-array';
+import { linkRadial } from 'd3-shape';
+import 'd3-transition';
 
 const SkillTree = ({ data }) => {
   const svgRef = useRef(null);
@@ -12,7 +16,7 @@ const SkillTree = ({ data }) => {
     if (!data || !svgRef.current) return;
     
     // Clear any existing SVG content
-    d3.select(svgRef.current).selectAll("*").remove();
+    select(svgRef.current).selectAll("*").remove();
     
     // Set up dimensions with reduced height for a more compact view
     const container = svgRef.current.parentElement;
@@ -29,17 +33,17 @@ const SkillTree = ({ data }) => {
     const radius = Math.min(width, height) / 2.5;
 
     // Create a more compact radial tree layout with tighter separation
-    const tree = d3.tree()
+    const treeLayout = treeLayoutFactory()
       .size([2 * Math.PI, radius])
       // Reduce separation between nodes for compactness
       .separation((a, b) => (a.parent == b.parent ? 1 : 1.8) / a.depth);
 
     // Process the data with d3 hierarchy
-    const root = tree(d3.hierarchy(data)
-      .sort((a, b) => d3.ascending(a.data.name, b.data.name)));
+    const root = treeLayout(hierarchy(data)
+      .sort((a, b) => ascending(a.data.name, b.data.name)));
 
     // Create the SVG container with reduced padding
-    const svg = d3.select(svgRef.current)
+    const svg = select(svgRef.current)
       .attr("width", width)
       .attr("height", height)
       .attr("viewBox", [-cx - 30, -cy - 30, width + 60, height + 60]) // Reduced padding
@@ -96,10 +100,8 @@ const SkillTree = ({ data }) => {
 
     // Create shared mouseover handler for both nodes and labels
     const handleMouseOver = function(event, d) {
-      const element = d3.select(this);
-      
       // Highlight the associated node
-      d3.selectAll(".skill-node")
+      selectAll(".skill-node")
         .filter(n => n.data.name === d.data.name)
         .transition()
         .duration(200)
@@ -111,7 +113,7 @@ const SkillTree = ({ data }) => {
       const parentNodeNames = parentNodes.map(n => n.data.name);
       
       // Highlight parent nodes
-      d3.selectAll(".skill-node")
+      selectAll(".skill-node")
         .filter(n => parentNodeNames.includes(n.data.name))
         .transition()
         .duration(200)
@@ -119,9 +121,9 @@ const SkillTree = ({ data }) => {
         .attr("filter", "url(#hover-glow)");
       
       // Highlight links that connect to parent nodes
-      d3.selectAll("path")
+      selectAll("path")
         .filter(function() {
-          const link = d3.select(this);
+          const link = select(this);
           const source = link.attr("data-source");
           const target = link.attr("data-target");
           
@@ -138,7 +140,7 @@ const SkillTree = ({ data }) => {
         .attr("stroke-opacity", 0.9);
       
       // Highlight the parent labels - removed font-weight styling
-      d3.selectAll(".skill-label")
+      selectAll(".skill-label")
         .filter(n => n.data.name === d.data.name || parentNodeNames.includes(n.data.name))
         .transition()
         .duration(200)
@@ -162,14 +164,14 @@ const SkillTree = ({ data }) => {
     // Create shared mouseout handler for both nodes and labels
     const handleMouseOut = function(event, d) {
       // Reset this node
-      d3.selectAll(".skill-node")
+      selectAll(".skill-node")
         .transition()
         .duration(300)
         .attr("r", n => n.data.size || (n.children ? 3 : 2.5)) // Smaller nodes but keep text readable
         .attr("filter", "url(#glow)");
       
       // Reset all links
-      d3.selectAll("path")
+      selectAll("path")
         .transition()
         .duration(300)
         .attr("stroke", "#4B5563")
@@ -177,7 +179,7 @@ const SkillTree = ({ data }) => {
         .attr("stroke-opacity", 0.5);
       
       // Reset all labels - removed font-weight styling
-      d3.selectAll(".skill-label")
+      selectAll(".skill-label")
         .transition()
         .duration(300)
         .attr("stroke-width", 2);
@@ -195,7 +197,7 @@ const SkillTree = ({ data }) => {
       .data(root.links())
       .join("path")
       .attr("stroke", "#4B5563") // Gray-600
-      .attr("d", d3.linkRadial()
+      .attr("d", linkRadial()
         .angle(d => d.x)
         .radius(d => d.y))
       .attr("stroke-dasharray", function() {
@@ -227,7 +229,7 @@ const SkillTree = ({ data }) => {
       .on("mouseout", handleMouseOut)
       .on("click", function(event, d) {
         // Pulse animation on click
-        d3.select(this)
+        select(this)
           .transition()
           .duration(100)
           .attr("r", d.data.size ? d.data.size * 1.4 : (d.children ? 6 : 4))
@@ -279,7 +281,7 @@ const SkillTree = ({ data }) => {
       const newWidth = entries[0].contentRect.width;
       const newHeight = newWidth * 0.85; // Maintain compact aspect ratio
       
-      d3.select(svgRef.current)
+      select(svgRef.current)
         .attr("width", newWidth)
         .attr("height", newHeight)
         .attr("viewBox", [

--- a/src/components/MyStack/components/SkillTree/SkillTreeSVG.jsx
+++ b/src/components/MyStack/components/SkillTree/SkillTreeSVG.jsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from 'react';
-import * as d3 from 'd3';
+import { select, selectAll } from 'd3-selection';
+import { tree, hierarchy } from 'd3-hierarchy';
+import { ascending } from 'd3-array';
+import { linkRadial } from 'd3-shape';
+import 'd3-transition';
 import { getPathToRoot, createGlowFilters } from './utils';
 
 const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
@@ -16,7 +20,7 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
     if (!data || !svgRef.current) return;
     
     // Clear any existing SVG content and animations
-    const svg = d3.select(svgRef.current);
+    const svg = select(svgRef.current);
     svg.selectAll("*").remove();
     
     // Set up dimensions with extra padding to prevent cropping
@@ -34,13 +38,13 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
     const radius = Math.min(width, height) / 2.2;
 
     // Create a radial tree layout
-    const tree = d3.tree()
+    const treeLayout = tree()
       .size([2 * Math.PI, radius])
       .separation((a, b) => (a.parent == b.parent ? 1.2 : 2.2) / a.depth);
 
     // Process the data with d3 hierarchy
-    const root = tree(d3.hierarchy(data)
-      .sort((a, b) => d3.ascending(a.data.name, b.data.name)));
+    const root = treeLayout(hierarchy(data)
+      .sort((a, b) => ascending(a.data.name, b.data.name)));
 
     // Create the SVG container with a larger viewBox to prevent cropping
     svg.attr("width", width)
@@ -53,10 +57,8 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
 
     // Create shared mouseover handler for both nodes and labels
     const handleMouseOver = function(event, d) {
-      const element = d3.select(this);
-      
       // Highlight the associated node
-      d3.selectAll(".skill-node")
+      selectAll(".skill-node")
         .filter(n => n.data.name === d.data.name)
         .transition()
         .duration(200)
@@ -68,7 +70,7 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
       const ancestorSet = new Set([d.data.name, ...pathToRoot.map(n => n.data.name)]);
 
       // Highlight only ancestor nodes on the path to root
-      d3.selectAll(".skill-node")
+      selectAll(".skill-node")
         .filter(n => ancestorSet.has(n.data.name))
         .transition()
         .duration(200)
@@ -76,9 +78,9 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
         .attr("filter", "url(#hover-glow)");
 
       // Highlight only links where BOTH endpoints are on the ancestor path
-      d3.selectAll("path")
+      selectAll("path")
         .filter(function() {
-          const link = d3.select(this);
+          const link = select(this);
           const source = link.attr("data-source");
           const target = link.attr("data-target");
           return ancestorSet.has(source) && ancestorSet.has(target);
@@ -90,7 +92,7 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
         .attr("stroke-opacity", 0.9);
       
       // Highlight the label
-      d3.selectAll(".skill-label")
+      selectAll(".skill-label")
         .filter(n => n.data.name === d.data.name)
         .transition()
         .duration(200)
@@ -114,14 +116,14 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
     // Create shared mouseout handler for both nodes and labels
     const handleMouseOut = function(event, d) {
       // Reset this node
-      d3.selectAll(".skill-node")
+      selectAll(".skill-node")
         .transition()
         .duration(300)
         .attr("r", n => n.data.size || (n.children ? 4 : 3))
         .attr("filter", "url(#glow)");
       
       // Reset all links
-      d3.selectAll("path")
+      selectAll("path")
         .transition()
         .duration(300)
         .attr("stroke", "#4B5563")
@@ -129,7 +131,7 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
         .attr("stroke-opacity", 0.6);
       
       // Reset all labels
-      d3.selectAll(".skill-label")
+      selectAll(".skill-label")
         .transition()
         .duration(300)
         .style("font-weight", "normal")
@@ -148,7 +150,7 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
       .data(root.links())
       .join("path")
       .attr("stroke", "#4B5563") // Gray-600
-      .attr("d", d3.linkRadial()
+      .attr("d", linkRadial()
         .angle(d => d.x)
         .radius(d => d.y))
       .attr("data-source", d => d.source.data.name)
@@ -169,7 +171,7 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
       .on("mouseout", handleMouseOut)
       .on("click", function(event, d) {
         // Pulse animation on click
-        d3.select(this)
+        select(this)
           .transition()
           .duration(100)
           .attr("r", d.data.size ? d.data.size * 1.5 : (d.children ? 8 : 6))
@@ -207,7 +209,7 @@ const SkillTreeSVG = ({ data, onNodeHover, onNodeLeave }) => {
       const newWidth = entries[0].contentRect.width;
       const newHeight = newWidth; // Maintain square aspect
       
-      d3.select(svgRef.current)
+      select(svgRef.current)
         .attr("width", newWidth)
         .attr("height", newHeight)
         .attr("viewBox", [


### PR DESCRIPTION
## Summary
Documents how caching and revalidation work across routes and APIs, tightens a couple of response headers, and applies Next.js and D3 optimizations to reduce JS size and work on the main thread.

## What changed
### Docs
`docs/adr/0001-caching-model.md` — caching model, route/API table with TTLs, and follow-up tickets (on-demand revalidation, segment-config clarity, no-store on views/reactions, RSS Last-Modified from content).
API

GET `/api/rss` — ETag is a SHA-1 of the XML body (stable when the feed is unchanged).
GET `/api/articles` — Cache-Control aligned with blog list / RSS (1h SWR, 2h stale-while-revalidate).
Performance

next.config.js — experimental.optimizePackageImports for lucide-react and framer-motion; compiler.removeConsole in production (excludes error / warn).
SkillTree.jsx and SkillTree/SkillTreeSVG.jsx — modular D3 imports instead of the full d3 package for smaller My Stack chunks.

## How to review
Skim the ADR for the route matrix and known trade-offs.
Spot-check the two API routes and the skill-tree D3 imports.
Run `npm run build` / `npm test` if you are validating locally.