### PR TITLE
Fix Open Graph image aspect ratio metadata

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -42,14 +42,14 @@ export const metadata = {
     images: [
       {
         url: '/cover.jpg',
-        width: 1200,
-        height: 630,
+        width: 1004,
+        height: 1004,
         alt: 'Ayushman Gupta Portfolio',
       },
     ],
   },
   twitter: {
-    card: 'summary_large_image',
+    card: 'summary',
     title: 'Ayushman Gupta | Fullstack Engineer',
     description: 'Personal portfolio and blog of Ayushman Gupta, a developer and designer specializing in web development and creative solutions.',
     images: ['/cover.jpg'],


### PR DESCRIPTION
### Motivation
- The site `openGraph` metadata declared a 1200×630 banner while `public/cover.jpg` is square, which caused the shared preview image to stretch in some social clients.

### Description
- Updated `src/app/layout.jsx` to set the OG `images` entry to `width: 1004` and `height: 1004` and switched the Twitter `card` from `summary_large_image` to `summary` to match the square cover art.

### Testing
- Ran a small automated JPEG header parser against `public/cover.jpg` which returned `1004x1004`, confirming the new metadata matches the actual image dimensions (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a048889241083248dd5afd0450f5eed)