### PR TITLE
Improve blog page typography readability

### DIFF
--- a/src/components/ArticleCardOptimized.jsx
+++ b/src/components/ArticleCardOptimized.jsx
@@ -45,7 +45,7 @@ export default function ArticleCard({ details, index }) {
           )}
         </div>
         <div className="p-6 md:p-8">
-          <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-gray-400 dark:text-gray-500">
+          <span className="text-xs font-mono tracking-[0.16em] uppercase text-gray-400 dark:text-gray-500">
             In Development
           </span>
           <h3
@@ -65,7 +65,7 @@ export default function ArticleCard({ details, index }) {
     >
       {/* Article index badge */}
       <div className="absolute top-3 left-3 z-10">
-        <span className="text-[9px] font-mono tracking-[0.2em] text-gray-500 dark:text-gray-400 bg-white/85 dark:bg-black/80 backdrop-blur-sm px-2 py-0.5">
+        <span className="text-xs font-mono tracking-[0.16em] text-gray-600 dark:text-gray-400 bg-white/85 dark:bg-black/80 backdrop-blur-sm px-2 py-0.5">
           {indexStr}
         </span>
       </div>
@@ -88,10 +88,10 @@ export default function ArticleCard({ details, index }) {
       <div className="p-6 md:p-8">
         {/* Meta row */}
         <div className="flex items-center justify-between mb-4">
-          <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-gray-500 dark:text-gray-400 group-hover:text-black dark:group-hover:text-white transition-colors duration-200">
+          <span className="text-xs font-mono tracking-[0.16em] uppercase text-gray-600 dark:text-gray-400 group-hover:text-black dark:group-hover:text-white transition-colors duration-200">
             {details.type}
           </span>
-          <div className="flex items-center gap-2 text-[9px] font-mono text-gray-400 dark:text-gray-500">
+          <div className="flex items-center gap-2 text-xs font-mono text-gray-500 dark:text-gray-500">
             {details.readingTime && (
               <>
                 <span>{formatReadingTime(details.readingTime)}</span>
@@ -110,7 +110,7 @@ export default function ArticleCard({ details, index }) {
         </h3>
 
         {details.introduction && (
-          <p className="text-gray-500 dark:text-gray-400 text-sm leading-relaxed line-clamp-3 font-light">
+          <p className="text-gray-600 dark:text-gray-300 text-base leading-relaxed line-clamp-3 font-light">
             {details.introduction}
           </p>
         )}

--- a/src/components/ArticleGrid.jsx
+++ b/src/components/ArticleGrid.jsx
@@ -10,7 +10,7 @@ export default function ArticleGrid({ articles }) {
           <h3 className="text-xl font-light text-black dark:text-white mb-3 tracking-wide">
             No Articles Found
           </h3>
-          <p className="text-gray-500 dark:text-gray-400 text-sm leading-relaxed max-w-sm font-light">
+          <p className="text-gray-600 dark:text-gray-300 text-base leading-relaxed max-w-sm font-light">
             No articles are currently available in this selection.
           </p>
         </div>

--- a/src/components/ArticleSearchAndFilter.jsx
+++ b/src/components/ArticleSearchAndFilter.jsx
@@ -134,7 +134,7 @@ export default function ArticleSearchAndFilter({ initialArticles = [], articleTy
               placeholder="Search archives..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full h-10 pl-12 pr-4 text-sm bg-transparent border border-gray-200 dark:border-gray-700 text-black dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-black dark:focus:border-white transition-colors duration-300"
+              className="w-full h-10 pl-12 pr-4 text-base bg-transparent border border-gray-200 dark:border-gray-700 text-black dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-black dark:focus:border-white transition-colors duration-300"
             />
             <motion.div
               className="absolute bottom-0 left-0 h-px bg-black dark:bg-white origin-left"
@@ -154,7 +154,7 @@ export default function ArticleSearchAndFilter({ initialArticles = [], articleTy
                 <motion.button
                   key={type}
                   onClick={() => handleFilterChange(type)}
-                  className={`flex-1 sm:flex-initial px-3 py-2 text-xs font-medium tracking-[0.1em] uppercase transition-all duration-300 whitespace-nowrap border sm:border-0 ${
+                  className={`flex-1 sm:flex-initial px-4 py-2.5 text-sm font-medium tracking-[0.1em] uppercase transition-all duration-300 whitespace-nowrap border sm:border-0 ${
                     filter === type
                       ? 'bg-black dark:bg-white text-white dark:text-black border-black dark:border-white'
                       : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white'
@@ -172,7 +172,7 @@ export default function ArticleSearchAndFilter({ initialArticles = [], articleTy
           {/* Sort Control */}
           <motion.button
             onClick={() => setSortOrder(sortOrder === "newest" ? "oldest" : "newest")}
-            className="inline-flex items-center justify-center gap-2 px-3 py-2 border border-gray-200 dark:border-gray-700 text-xs font-medium tracking-[0.1em] uppercase text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white hover:border-black dark:hover:border-white transition-all duration-300 w-full sm:w-auto"
+            className="inline-flex items-center justify-center gap-2 px-3 py-2 border border-gray-200 dark:border-gray-700 text-sm font-medium tracking-[0.08em] uppercase text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white hover:border-black dark:hover:border-white transition-all duration-300 w-full sm:w-auto"
             whileHover={{ y: -1 }}
             whileTap={{ y: 0 }}
           >
@@ -191,7 +191,7 @@ export default function ArticleSearchAndFilter({ initialArticles = [], articleTy
         className="text-center mb-6"
         variants={itemVariants}
       >
-        <div className="inline-flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400 font-mono">
+        <div className="inline-flex items-center gap-3 text-sm text-gray-600 dark:text-gray-400 font-mono">
           <div className="h-px w-4 bg-current" />
           <span>
             {filteredArticles.length} ARTICLE{filteredArticles.length !== 1 ? 'S' : ''}
@@ -212,7 +212,7 @@ export default function ArticleSearchAndFilter({ initialArticles = [], articleTy
             <h3 className="text-3xl font-light text-black dark:text-white mb-4">
               No Results Found
             </h3>
-            <p className="text-gray-600 dark:text-gray-400 mb-8 leading-relaxed">
+            <p className="text-base text-gray-600 dark:text-gray-400 mb-8 leading-relaxed">
               The archives don't contain any articles matching your current search criteria.
             </p>
             <motion.button
@@ -220,7 +220,7 @@ export default function ArticleSearchAndFilter({ initialArticles = [], articleTy
                 setSearchTerm("");
                 handleFilterChange("All");
               }}
-              className="inline-flex items-center gap-3 px-8 py-3 border border-gray-200 dark:border-gray-700 text-sm font-medium tracking-[0.1em] uppercase text-black dark:text-white hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black transition-all duration-300"
+              className="inline-flex items-center gap-3 px-8 py-3 border border-gray-200 dark:border-gray-700 text-base font-medium tracking-[0.08em] uppercase text-black dark:text-white hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black transition-all duration-300"
               whileHover={{ y: -2 }}
               whileTap={{ y: 0 }}
             >

--- a/src/components/FeaturedArticle.jsx
+++ b/src/components/FeaturedArticle.jsx
@@ -50,7 +50,7 @@ export default function FeaturedArticle({ article }) {
           <div className="relative p-8 md:p-10 lg:p-14 flex flex-col justify-between order-2 md:order-1 min-h-[280px]">
             <div>
               {/* Meta row */}
-              <div className="flex flex-wrap items-center gap-2 mb-6 text-[10px] font-mono tracking-[0.18em] uppercase text-gray-500 dark:text-gray-400">
+              <div className="flex flex-wrap items-center gap-2 mb-6 text-sm font-mono tracking-[0.12em] uppercase text-gray-600 dark:text-gray-400">
                 <span>{article.type}</span>
                 <span className="text-gray-300 dark:text-gray-600">&middot;</span>
                 <span>{formatDate(article.date)}</span>
@@ -71,14 +71,14 @@ export default function FeaturedArticle({ article }) {
 
               {/* Introduction */}
               {article.introduction && (
-                <p className="text-sm md:text-base leading-relaxed text-gray-600 dark:text-gray-400 font-light line-clamp-3">
+                <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-300 font-light line-clamp-3">
                   {article.introduction}
                 </p>
               )}
             </div>
 
             {/* CTA */}
-            <div className="flex items-center gap-3 mt-8 text-[10px] font-mono tracking-[0.18em] uppercase text-black dark:text-white">
+            <div className="flex items-center gap-3 mt-8 text-sm font-mono tracking-[0.12em] uppercase text-black dark:text-white">
               <span>Read article</span>
               <div className="h-px w-8 bg-current group-hover:w-14 transition-all duration-300" />
               <svg

--- a/src/components/HeroBanner.jsx
+++ b/src/components/HeroBanner.jsx
@@ -35,7 +35,7 @@ function HeroBanner() {
       >
         <div className="h-[2px] flex-1 bg-black dark:bg-white" />
         <div className="px-5">
-          <span className="text-[9px] tracking-[0.35em] font-mono text-gray-500 dark:text-gray-400 uppercase">
+          <span className="text-xs tracking-[0.22em] font-mono text-gray-500 dark:text-gray-400 uppercase">
             Vol. I &mdash; 2025
           </span>
         </div>
@@ -85,7 +85,7 @@ function HeroBanner() {
               {i > 0 && (
                 <span className="text-gray-300 dark:text-gray-600 text-sm">&middot;</span>
               )}
-              <span className="text-[9px] tracking-[0.25em] font-mono text-gray-400 dark:text-gray-500 uppercase">
+              <span className="text-xs tracking-[0.16em] font-mono text-gray-400 dark:text-gray-500 uppercase">
                 {tag}
               </span>
             </React.Fragment>
@@ -101,7 +101,7 @@ function HeroBanner() {
         animate={{ opacity: 1 }}
         transition={{ duration: 0.6, delay: 0.6 }}
       >
-        <span className="text-[9px] tracking-[0.25em] font-mono text-gray-400 dark:text-gray-500 uppercase">
+        <span className="text-xs tracking-[0.16em] font-mono text-gray-400 dark:text-gray-500 uppercase">
           Written by
         </span>{" "}
         <span


### PR DESCRIPTION
### Motivation
- Small UI text on the `/blog` page made controls and article metadata hard to read, so sizes were increased to improve legibility while keeping the existing layout and visual hierarchy.

### Description
- Increased control and label font sizes in the listing controls: search input switched to `text-base`, filter chips and sort button updated to `text-sm`, and results summary made `text-sm` in `src/components/ArticleSearchAndFilter.jsx`.
- Raised article card metadata and body copy sizes: index/type/date labels set to `text-xs` and introduction copy to `text-base` in `src/components/ArticleCardOptimized.jsx` and empty-state copy adjusted in `src/components/ArticleGrid.jsx` for consistency.
- Increased featured article meta, CTA and intro typography (meta -> `text-sm`, intro -> `text-base`/`md:text-lg`) in `src/components/FeaturedArticle.jsx`.
- Increased small masthead, tag and byline label sizes in the hero banner (to `text-xs`) in `src/components/HeroBanner.jsx`.
- Files changed: `ArticleSearchAndFilter.jsx`, `ArticleCardOptimized.jsx`, `FeaturedArticle.jsx`, `HeroBanner.jsx`, `ArticleGrid.jsx`.

### Testing
- Ran `npm run lint`, which failed with `next lint` due to an existing project/script environment issue (invalid directory `/workspace/odyssey/lint`), so no further automated checks ran successfully.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09aceb6e8c8324abb50bfb5af63097)